### PR TITLE
Add an script to fork the hyperbox repositories

### DIFF
--- a/fork
+++ b/fork
@@ -26,12 +26,14 @@ echo ""
 
 # show usage information
 show_usage() {
-    echo "usage:  fork [-org <organization>] [--create] <username>" 
+    echo "usage:  fork [--org <organization>]"
+    echo "        fork -h" 
     echo ""
-    echo "Forks all the hyperbox repositories into new repositories in a Github user or organization"
-    echo "  <username>                   Github username"
-    echo "  -o | --org <organization>    Create the forks in a organization instead of the username"
-    echo "  -c | --create                Ask for a password and create the forks in Github"
+    echo "Forks all the hyperbox repositories into new repositories in a Github user or organization."
+    echo "By default, the fork repositories are cretaed in the current hub user"
+    echo 
+    echo "  -o | --org <organization>    Create the forks in a organization"
+    echo "  -h                           Show usage"
     echo ""
     exit 1
 }
@@ -44,107 +46,55 @@ die() {
 
 # function to fork the repository in the current folder
 fork_current_repo () {
-    local PWD="$(pwd)"
-    local REPONAME="$(basename $PWD)"
-    local REPOURL="https://github.com/$ORGNAME/$REPONAME"
-
-    # rename origin to upstream if upstream does not exist
-    if [ -z "$(git config remote.upstream.url)" ]; then
-        echo "    renaming origin remote to upstream"
-        git remote rename origin upstream
-    fi
-
-    # remove origin if it exists
-    if [ ! -z "$(git config remote.origin.url)" ]; then
-        echo "    removing origin remote"
-        git remote remove origin
-    fi
-    # add the origin to the new repository
-    echo "    adding the new origin remote: $REPOURL.git"
-    git remote add origin $REPOURL.git
-
-    # create the repository in Github if it does not exist
-    if [ "$CREATE" == "1" ]; then
-        if [ ! "$(curl -s --head GET $REPOURL 2>&1 | grep 404 | wc -l)" == "0" ]; then
-            echo "    creating fork-repository $REPOURL in Github"
-            if [ ! "$ORGNAME" == "$USERNAME" ]; then
-                curl -s "https://api.github.com/repos/hyperbox/$REPONAME/forks" -d "{"\""organization"\"":"\""$ORGNAME"\""}" -K- <<< "user="\""$USERNAME:$PASSWD"\"""  > /dev/null
-            else
-                curl -s "https://api.github.com/repos/hyperbox/$REPONAME/forks"  -d '' -K- <<< "user="\""$USERNAME:$PASSWD"\""" > /dev/null
-            fi 
-        else
-            echo "    fork-repository $REPOURL already exists in Github"
-        fi
+    # fork the repository in Github
+    if [ -z $ORGNAME ]; then
+        hub fork
+    else
+        hub fork --org=$ORGNAME
     fi
 }
 
-CREATE=0
-USERNAME=""
-ORGNAME=""
-
-# show usage information if not parameter is given
-if [ -z "$1" ]; then
+# show usage information
+if [ "$1" = "-h" ]; then
     show_usage
     die
 fi
 
-# process parameters
-while :; do
-    if [ -z "$1" ]; then
-        break
-    fi   
-    case $1 in
-        -o|--org)
-            if [ "$2" ]; then
-                ORGNAME=$2
-                shift
-            else
-                die 'ERROR: "--org" requires a non-empty option'
-            fi
-            ;;
-         -c|--create)
-            CREATE=1
-            ;;
-         *) 
-            if [ -z "$USERNAME" ]; then
-                USERNAME=$1
-            else
-                die 'ERROR: you cannot provide two usernames'
-            fi
-            ;; 
-    esac
-    shift
-done
-
-if [ -z "$USERNAME" ]; then
-    die 'ERROR: you must  provide a username'
-fi 
-if [ -z "$ORGNAME" ]; then
-    ORGNAME=$USERNAME
+# determine organization name if it is provided
+ORGNAME=""
+if [ "$1" = "--org" -o "$1" = "-o" ]; then
+    if [ "$2" ]; then
+        ORGNAME=$2
+    else
+        die 'ERROR: "--org" requires a non-empty organization name'
+    fi
 fi
 
-# check if the modules have been initialized
-if [ ! -f "./modules/client/.gitignore" ]; then
-    die "ERROR: you must initialize the submodules first. Run the init script"
+# check if hub is installed
+if [ ! -x "$(command -v hub)" ]; then
+    die "ERROR: the 'hub' command is not installed. Please check https://github.com/github/hub"
 fi
 
-# Read the password to be used to create the repositories in Github
-if [ "$CREATE" == "1" ]; then
-    echo "Github password (used to create the forks):"
-    read -s PASSWD
-    echo
-    CURL_AUTH="$USERNAME:$PASSWD"
-fi
 
 # determine the set of modules in the repository
 MODULES=$(grep path .gitmodules | sed  's/.*= //')
+
+# check if the modules have been initialized
+while read -r module; do
+    pushd $module > /dev/null
+    if [ ! -f ".gitignore" ]; then
+        die "ERROR: $module has been not initialized. You must run the 'init' script before."
+    fi
+    popd > /dev/null
+done <<< "$MODULES"
 
 # fork the main repository
 echo "forking parent repository"
 fork_current_repo 
 
-# fork each submodule
+# for each submodule
 while read -r module; do
+    echo
     echo "forking module: $module"
     pushd $module > /dev/null
     fork_current_repo

--- a/fork
+++ b/fork
@@ -1,0 +1,156 @@
+#!/bin/bash -e
+###########################################################################
+#
+# Hyperbox - Virtual Infrastructure Manager
+# Copyright (C) 2015 Maxime Dor
+#
+# http://kamax.io/hbox/
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###########################################################################
+
+echo "Hyperbox Fork utility"
+echo ""
+
+# show usage information
+show_usage() {
+    echo "usage:  fork [-org <organization>] [--create] <username>" 
+    echo ""
+    echo "Forks all the hyperbox repositories into new repositories in a Github user or organization"
+    echo "  <username>                   Github username"
+    echo "  -o | --org <organization>    Create the forks in a organization instead of the username"
+    echo "  -c | --create                Ask for a password and create the forks in Github"
+    echo ""
+    exit 1
+}
+
+# exit showing an error message
+die() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+
+# function to fork the repository in the current folder
+fork_current_repo () {
+    local PWD="$(pwd)"
+    local REPONAME="$(basename $PWD)"
+    local REPOURL="https://github.com/$ORGNAME/$REPONAME"
+
+    # rename origin to upstream if upstream does not exist
+    if [ -z "$(git config remote.upstream.url)" ]; then
+        echo "    renaming origin remote to upstream"
+        git remote rename origin upstream
+    fi
+
+    # remove origin if it exists
+    if [ ! -z "$(git config remote.origin.url)" ]; then
+        echo "    removing origin remote"
+        git remote remove origin
+    fi
+    # add the origin to the new repository
+    echo "    adding the new origin remote: $REPOURL.git"
+    git remote add origin $REPOURL.git
+
+    # create the repository in Github if it does not exist
+    if [ "$CREATE" == "1" ]; then
+        if [ ! "$(curl -s --head GET $REPOURL 2>&1 | grep 404 | wc -l)" == "0" ]; then
+            echo "    creating fork-repository $REPOURL in Github"
+            if [ ! "$ORGNAME" == "$USERNAME" ]; then
+                curl -s "https://api.github.com/repos/hyperbox/$REPONAME/forks" -d "{"\""organization"\"":"\""$ORGNAME"\""}" -K- <<< "user="\""$USERNAME:$PASSWD"\"""  > /dev/null
+            else
+                curl -s "https://api.github.com/repos/hyperbox/$REPONAME/forks"  -d '' -K- <<< "user="\""$USERNAME:$PASSWD"\""" > /dev/null
+            fi 
+        else
+            echo "    fork-repository $REPOURL already exists in Github"
+        fi
+    fi
+}
+
+CREATE=0
+USERNAME=""
+ORGNAME=""
+
+# show usage information if not parameter is given
+if [ -z "$1" ]; then
+    show_usage
+    die
+fi
+
+# process parameters
+while :; do
+    if [ -z "$1" ]; then
+        break
+    fi   
+    case $1 in
+        -o|--org)
+            if [ "$2" ]; then
+                ORGNAME=$2
+                shift
+            else
+                die 'ERROR: "--org" requires a non-empty option'
+            fi
+            ;;
+         -c|--create)
+            CREATE=1
+            ;;
+         *) 
+            if [ -z "$USERNAME" ]; then
+                USERNAME=$1
+            else
+                die 'ERROR: you cannot provide two usernames'
+            fi
+            ;; 
+    esac
+    shift
+done
+
+if [ -z "$USERNAME" ]; then
+    die 'ERROR: you must  provide a username'
+fi 
+if [ -z "$ORGNAME" ]; then
+    ORGNAME=$USERNAME
+fi
+
+# check if the modules have been initialized
+if [ ! -f "./modules/client/.gitignore" ]; then
+    die "ERROR: you must initialize the submodules first. Run the init script"
+fi
+
+# Read the password to be used to create the repositories in Github
+if [ "$CREATE" == "1" ]; then
+    echo "Github password (used to create the forks):"
+    read -s PASSWD
+    echo
+    CURL_AUTH="$USERNAME:$PASSWD"
+fi
+
+# determine the set of modules in the repository
+MODULES=$(grep path .gitmodules | sed  's/.*= //')
+
+# fork the main repository
+echo "forking parent repository"
+fork_current_repo 
+
+# fork each submodule
+while read -r module; do
+    echo "forking module: $module"
+    pushd $module > /dev/null
+    fork_current_repo
+    popd > /dev/null
+done <<< "$MODULES"
+
+# That's all folks
+echo ""
+echo "done."

--- a/fork
+++ b/fork
@@ -26,15 +26,16 @@ echo ""
 
 # show usage information
 show_usage() {
-    echo "usage:  fork [--org <organization>]"
+    echo "usage:  fork [--org <organization>] [--create]"
     echo "        fork -h" 
     echo ""
     echo "Forks all the hyperbox repositories into new repositories in a Github user or organization."
-    echo "By default, the fork repositories are cretaed in the current hub user"
+    echo "By default, the fork repositories are configured and created in the current hub user"
     echo 
-    echo "  -o | --org <organization>    Create the forks in a organization"
-    echo "  -h                           Show usage"
-    echo ""
+    echo "  -o | --org <organization>  Configure the forks in a organization"
+    echo "  -c | --create              Create the forks in Github"
+    echo "  -h                         Show usage"
+    echo 
     exit 1
 }
 
@@ -46,33 +47,85 @@ die() {
 
 # function to fork the repository in the current folder
 fork_current_repo () {
-    # fork the repository in Github
-    if [ -z $ORGNAME ]; then
-        hub fork
+    if [ "$CREATE" == "0" ]; then
+        # add the new remote
+        # delete the remote if exists, because hub may fail
+        if [ -z $ORGNAME ]; then
+            local USERNAME="$(git config user.name)"
+            if [ ! -z "$(git config remote.$USERNAME.url)" ]; then
+                echo "removing $USERNAME remote"
+                git remote remove $USERNAME
+                sleep .5
+            fi
+            echo "creating $USERNAME remote"
+            hub remote add origin
+
+        else
+            if [ ! -z "$(git config remote.$ORGNAME.url)" ]; then
+                echo "removing $ORGNAME remote"
+                git remote remove $ORGNAME
+                sleep .5
+            fi
+            echo "creating $ORGNAME remote"
+            hub remote add $ORGNAME
+        fi
+        sleep .5
+
     else
-        hub fork --org=$ORGNAME
+        # fork the repository in Github
+        if [ -z $ORGNAME ]; then
+            hub fork
+        else
+            hub fork --org=$ORGNAME
+        fi
     fi
 }
 
+
+CREATE=0
+ORGNAME=""
+
 # show usage information
-if [ "$1" = "-h" ]; then
+if [ -z "$1" -o  "$1" = "-h" ]; then
     show_usage
     die
 fi
 
-# determine organization name if it is provided
-ORGNAME=""
-if [ "$1" = "--org" -o "$1" = "-o" ]; then
-    if [ "$2" ]; then
-        ORGNAME=$2
-    else
-        die 'ERROR: "--org" requires a non-empty organization name'
-    fi
-fi
+# process parameters
+while :; do
+    if [ -z "$1" ]; then
+        break
+    fi   
+    case $1 in
+        -o|--org)
+            if [ ! -z "$ORGNAME"]; then
+                die "ERROR: you cannot provide two organization names"
+            fi
+            if [ "$2" ]; then
+                ORGNAME=$2
+                shift
+            else
+                die 'ERROR: "--org" requires a non-empty option'
+            fi
+            ;;
+         -c|--create)
+            CREATE=1
+            ;;
+         *) 
+            echo 'ERROR: wrong parameters'
+            show_usage
+            die
+            ;; 
+    esac
+    shift
+done
+
 
 # check if hub is installed
 if [ ! -x "$(command -v hub)" ]; then
-    die "ERROR: the 'hub' command is not installed. Please check https://github.com/github/hub"
+    echo "ERROR: the 'hub' command is not installed."
+    echo "You may get more information at https://github.com/github/hub"
+    die
 fi
 
 
@@ -97,7 +150,7 @@ while read -r module; do
     echo
     echo "forking module: $module"
     pushd $module > /dev/null
-    fork_current_repo
+    fork_current_repo 
     popd > /dev/null
 done <<< "$MODULES"
 


### PR DESCRIPTION
Add a bash script that configure and creates forks of the hyperbox repositories
Fix hyperbox/hyperbox#29

---
### Description
The root directory has a `fork` script to configure and create forks of the hyperbox repositories.
- The developer must clone the root repository and run the `init` script first.
- The script requires `curl` to create the fork-repositories in Github

---
### Running the script
The script configures an `upstream` remote with the original repository and change the `origin` repository to a fork-repository. It may configure the fork-repositories in the user account or in an organization. Optionally, it may create the forks in Github,

1. To configure the forks using repositories in a user account you must provide a *username*. F>or instance, if you provide the `user` as username, it configures fork-repositories such as https://github.com/user/hyperbox. The script does not create the forks if the `--create` option is not provided.
```
./fork user                      
```

2.  To configure the forks using an organization, you must use the `-o` or the `--org` options and provide an *organization* name. For instance, if you provide `organiz` as the *organization*, the script configures fork-repositories such as https://github.com/organiz/hyperbox.
``` 
./fork user --org organiz
```

3. To create the forks in Github, you must use the `-c` or the `--create` options. The script ask for the Github password and creates the forks. It supports passwords with white spaces and do not show the password in any `ps` listing. It uses `curl` and the Github REST API to create the forks.
``` 
./fork user --create
./fork user --org organiz --create
```

**NOTE:** You can run the script multiple times, for instance, if you wanna create new forks or had an error. The script shows error messages if the parameters are not provided correctly and if the cloned-repository has not been initialized.